### PR TITLE
support more speech formats

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.6.7"
+    "version": "0.6.8"
   },
   "servers": [
     {
@@ -3875,11 +3875,18 @@
           {
             "name": "response_format",
             "in": "query",
-            "description": "Format for the response",
+            "description": "Format for the response. Use speech_srt or speech_vtt for subtitle formats, speech_markdown for a diarized transcript, or speech_text for plain timestamped text.",
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["json", "markdown"]
+              "enum": [
+                "json",
+                "markdown",
+                "speech_srt",
+                "speech_vtt",
+                "speech_markdown",
+                "speech_text"
+              ]
             }
           },
           {


### PR DESCRIPTION
updates:
- bump api version
- expose more options for describe format specific to different speech transcript formats 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new response format options for file segment descriptions. Users can now export results in subtitle formats (SRT, VTT), speech-focused Markdown, and plain text, alongside existing JSON and Markdown outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->