### PR TITLE
add grain to spec

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4243,7 +4243,7 @@
           {
             "name": "title_search",
             "in": "query",
-            "description": "Title search filter. Applies to Grain connectors only.",
+            "description": "Title search filter. Applies to Grain connectors only. See the [Grain documentation](https://developers.grain.com/#recording-filter) for more details.",
             "required": false,
             "schema": {
               "type": "string"
@@ -4252,7 +4252,7 @@
           {
             "name": "team",
             "in": "query",
-            "description": "Team filter. Applies to Grain connectors only.",
+            "description": "Team filter. Applies to Grain connectors only. See the [Grain documentation](https://developers.grain.com/#recording-filter) for more details.",
             "required": false,
             "schema": {
               "type": "string"
@@ -4261,7 +4261,7 @@
           {
             "name": "meeting_type",
             "in": "query",
-            "description": "Meeting type filter. Applies to Grain connectors only.",
+            "description": "Meeting type filter. Applies to Grain connectors only. See the [Grain documentation](https://developers.grain.com/#recording-filter) for more details.",
             "required": false,
             "schema": {
               "type": "string"

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4187,7 +4187,7 @@
           {
             "name": "from",
             "in": "query",
-            "description": "Start date for filtering (YYYY-MM-DD). Applies to Zoom connectors only.",
+            "description": "Start date for filtering (YYYY-MM-DD). Applies to Zoom and Grain connectors only.",
             "required": false,
             "schema": {
               "type": "string",
@@ -4197,7 +4197,7 @@
           {
             "name": "to",
             "in": "query",
-            "description": "End date for filtering (YYYY-MM-DD). Applies to Zoom connectors only.",
+            "description": "End date for filtering (YYYY-MM-DD). Applies to Zoom and Grain connectors only.",
             "required": false,
             "schema": {
               "type": "string",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.6.8"
+    "version": "0.6.9"
   },
   "servers": [
     {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -4239,6 +4239,33 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "title_search",
+            "in": "query",
+            "description": "Title search filter. Applies to Grain connectors only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "team",
+            "in": "query",
+            "description": "Team filter. Applies to Grain connectors only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "meeting_type",
+            "in": "query",
+            "description": "Meeting type filter. Applies to Grain connectors only.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -8284,7 +8311,8 @@
               "zoom",
               "gong",
               "recall",
-              "gcs"
+              "gcs",
+              "grain"
             ],
             "description": "Source of the file"
           }
@@ -10426,7 +10454,8 @@
               "zoom",
               "gong",
               "recall",
-              "gcs"
+              "gcs",
+              "grain"
             ],
             "description": "The type of data connector"
           },


### PR DESCRIPTION
# Summary
This PR updates the API specification for the Grain data connector.

Documentation: Added descriptions for three new query parameters (title_search, team, and meeting_type) to the listDataConnectorFiles endpoint.

Schema Updates: Added "Grain" as a valid option for the DataConnector type and the File source type.

Versioning: Bumped the API specification version to 0.6.9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grain as a new connector type, enabling integration of Grain data sources.
  * Added filtering capabilities for file discovery: title search, team selection, and meeting type filtering (available for Grain connectors).

* **Updates**
  * API specification version updated to 0.6.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->