### PR TITLE
Adding new segmentation strategy, bump to api version 0.7.0

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.6.9"
+    "version": "0.7.0"
   },
   "servers": [
     {
@@ -5882,7 +5882,7 @@
         "tags": ["Segments"],
         "summary": "Create a new segmentation job",
         "operationId": "createSegments",
-        "description": "Create intelligent segments for video or audio files based on shot detection or narrative analysis.\n\n**Audio File Support:**\n\n- Audio files support **narrative** criteria only (shot detection is not available for audio).\n- Audio files automatically use the 'balanced' strategy.\n\n**Note: YouTube URLs and audio files are supported for narrative-based segmentation only.** Shot-based segmentation requires direct video file access. Use Cloudglue Files, HTTP URLs, or files from data connectors for shot-based segmentation.\n\n**Narrative Segmentation Strategies:**\n\n- **comprehensive** (default for non-YouTube/non-audio files): Uses a VLM to deeply analyze logical segments of video. Only available for video files (not YouTube or audio).\n- **balanced** (default for YouTube videos and audio files): Balanced analysis approach using multiple modalities. Supports YouTube URLs and audio files.\n\n**YouTube URLs and Audio Files**: Automatically use the 'balanced' strategy. The strategy field is ignored, and other strategies will be rejected with an error.\n\n**Chapter Count Parameters:**\n\n- **number_of_chapters**: Target number of chapters. If only this is provided, min_chapters and max_chapters are calculated automatically.\n- **min_chapters**: Minimum number of chapters. If provided with number_of_chapters and max, validates min is less than or equal to number_of_chapters which is less than or equal to max.\n- **max_chapters**: Maximum number of chapters. If provided with number_of_chapters and min, validates min is less than or equal to number_of_chapters which is less than or equal to max.\n- If none are provided, chapter counts are calculated automatically based on file duration.",
+        "description": "Create intelligent segments for video or audio files based on shot detection or narrative analysis.\n\n**Audio File Support:**\n\n- Audio files support **narrative** criteria only (shot detection is not available for audio).\n- Audio files default to the 'balanced' strategy and may opt into 'transcript'.\n\n**Note: YouTube URLs and audio files are supported for narrative-based segmentation only.** Shot-based segmentation requires direct video file access. Use Cloudglue Files, HTTP URLs, or files from data connectors for shot-based segmentation.\n\n**Narrative Segmentation Strategies:**\n\n- **comprehensive** (default for non-YouTube/non-audio files): Uses a VLM to deeply analyze logical segments of video. Only available for video files (not YouTube or audio).\n- **balanced** (default for YouTube videos and audio files): Balanced analysis approach using multiple modalities. Supports YouTube URLs and audio files.\n- **transcript**: Cheap and fast speech-transcript-based segmentation. Requires a transcript and returns an error when none is available — use `balanced` for silent or visual-only content (or `comprehensive` for non-YouTube/non-audio video files).\n\n**YouTube URLs and Audio Files**: Only the 'balanced' and 'transcript' strategies are accepted. 'comprehensive' will be rejected with an error.\n\n**Chapter Count Parameters:**\n\n- **number_of_chapters**: Target number of chapters. If only this is provided, min_chapters and max_chapters are calculated automatically.\n- **min_chapters**: Minimum number of chapters. If provided with number_of_chapters and max, validates min is less than or equal to number_of_chapters which is less than or equal to max.\n- **max_chapters**: Maximum number of chapters. If provided with number_of_chapters and min, validates min is less than or equal to number_of_chapters which is less than or equal to max.\n- If none are provided, chapter counts are calculated automatically based on file duration.",
         "requestBody": {
           "description": "Segmentation job parameters",
           "content": {
@@ -5906,7 +5906,7 @@
             }
           },
           "400": {
-            "description": "Invalid request, missing required parameters, unsupported URL type (e.g., YouTube URLs with shot-based segmentation), or unsupported strategy for YouTube URLs (YouTube URLs only support 'balanced' strategy)",
+            "description": "Invalid request, missing required parameters, unsupported URL type (e.g., YouTube URLs with shot-based segmentation), or unsupported strategy for YouTube URLs and audio files (only 'balanced' and 'transcript' are accepted)",
             "content": {
               "application/json": {
                 "schema": {
@@ -12347,7 +12347,7 @@
         "properties": {
           "url": {
             "type": "string",
-            "description": "Input video or audio file URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public HTTP URLs, YouTube URLs (narrative criteria only), public TikTok video URLs, and files which have been granted access to Cloudglue via data connectors.\n\n**\u26a0\ufe0f Important: YouTube URLs and audio files are ONLY supported for narrative-based segmentation.** Shot-based segmentation requires direct video file access and does not support YouTube URLs or audio files. For YouTube URLs and audio files with narrative segmentation, the 'balanced' strategy is automatically used regardless of the strategy field value. Other strategies will be rejected with an error. Public TikTok video URLs will be scraped and stored automatically — subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information."
+            "description": "Input video or audio file URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public HTTP URLs, YouTube URLs (narrative criteria only), public TikTok video URLs, and files which have been granted access to Cloudglue via data connectors.\n\n**\u26a0\ufe0f Important: YouTube URLs and audio files are ONLY supported for narrative-based segmentation.** Shot-based segmentation requires direct video file access and does not support YouTube URLs or audio files. For YouTube URLs and audio files with narrative segmentation, only the 'balanced' and 'transcript' strategies are accepted; the 'comprehensive' strategy will be rejected with an error. Public TikTok video URLs will be scraped and stored automatically — subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information."
           },
           "criteria": {
             "type": "string",
@@ -12399,8 +12399,8 @@
           },
           "strategy": {
             "type": "string",
-            "enum": ["comprehensive", "balanced"],
-            "description": "Narrative segmentation strategy:\n\n\u2022 **comprehensive**: Uses a VLM to deeply analyze logical segments of video. Only available for video files (not YouTube or audio).\n\n\u2022 **balanced** (default): Balanced analysis approach using multiple modalities. Supports YouTube URLs and audio files.\n\n**Note**: YouTube URLs and audio files automatically use the 'balanced' strategy regardless of the strategy field value. The 'comprehensive' strategy is not supported for YouTube URLs or audio files."
+            "enum": ["comprehensive", "balanced", "transcript"],
+            "description": "Narrative segmentation strategy:\n\n\u2022 **comprehensive**: Uses a VLM to deeply analyze logical segments of video. Only available for video files (not YouTube or audio).\n\n\u2022 **balanced** (default): Balanced analysis approach using multiple modalities. Supports YouTube URLs and audio files.\n\n\u2022 **transcript**: Cheap and fast speech-transcript-based segmentation. Requires a transcript; returns an error for silent or visual-only content (use `balanced` instead, or `comprehensive` for non-YouTube/non-audio video files).\n\n**Note**: YouTube URLs and audio files only support the **balanced** and **transcript** strategies; **comprehensive** will be rejected with an error."
           },
           "number_of_chapters": {
             "type": "integer",


### PR DESCRIPTION
Bumps api version from `0.6.9` to `0.7.0` 

Incorporates new `transcript` strategy for segments/segmentation which relies purely on speech transcript for a cheap/fast option for narrative based segmentations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "transcript" as a new narrative segmentation strategy.
  * Implemented validation rules for YouTube URLs and audio file handling.

* **Documentation**
  * Updated POST /segments endpoint documentation with refined strategy requirements.
  * Clarified supported strategies for different media types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->