### PR TITLE
Mark include-gated Grain source_metadata fields nullable (API v0.7.4)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.3"
+    "version": "0.7.4"
   },
   "servers": [
     {
@@ -14331,14 +14331,16 @@
                 }
               }
             },
-            "description": "Meeting participants (include-gated by Grain)."
+            "nullable": true,
+            "description": "Meeting participants (include-gated by Grain). Null when requested but empty."
           },
           "highlights": {
             "type": "array",
             "items": {
               "type": "object"
             },
-            "description": "Clips / highlights (include-gated)."
+            "nullable": true,
+            "description": "Clips / highlights (include-gated). Null when requested but empty."
           },
           "ai_summary": {
             "type": "object",
@@ -14348,7 +14350,8 @@
                 "description": "Markdown AI summary."
               }
             },
-            "description": "AI summary (include-gated)."
+            "nullable": true,
+            "description": "AI summary (include-gated). Null when requested but empty."
           },
           "ai_action_items": {
             "type": "array",
@@ -14384,14 +14387,16 @@
                 }
               }
             },
-            "description": "AI action items (include-gated)."
+            "nullable": true,
+            "description": "AI action items (include-gated). Null when requested but empty."
           },
           "ai_template_sections": {
             "type": "array",
             "items": {
               "type": "object"
             },
-            "description": "AI template sections, shape varies by template (include-gated)."
+            "nullable": true,
+            "description": "AI template sections, shape varies by template (include-gated). Null when requested but empty."
           },
           "calendar_event": {
             "type": "object",
@@ -14419,7 +14424,8 @@
                 }
               }
             },
-            "description": "Related HubSpot company/deal ids (include-gated)."
+            "nullable": true,
+            "description": "Related HubSpot company/deal ids (include-gated). Null when requested but empty."
           }
         },
         "required": [


### PR DESCRIPTION
## Summary

- Bumps the spec to **v0.7.4**.
- Marks the six include-gated `GrainSourceMetadata` fields — `participants`, `highlights`, `ai_summary`, `ai_action_items`, `ai_template_sections`, `hubspot` — as `nullable: true`.
- Grain returns these fields as an explicit `null` (not omission) when they're requested but empty, so the API can legitimately serialize `"ai_summary": null` etc. The previous spec typed them as non-nullable, which is incorrect and makes generated SDK types reject valid responses. Mirrors the corresponding API fix.

## Test plan

- [x] `version` is `0.7.4` and `spec/openapi.json` is valid JSON.
- [x] The six fields under `GrainSourceMetadata` carry `nullable: true`; no other schemas touched.
- [ ] Regenerate the SDK from this spec and confirm the six fields are typed nullable (e.g. `ai_summary?: {...} | null`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* API specification updated to version 0.7.4 with improved null-value semantics.
* Multiple fields now explicitly support null values with clarified descriptions: meeting participants, highlights, AI summaries, action items, template sections, and HubSpot identifiers.
* Updated documentation clarifies that null is returned when gated content is requested but empty, enabling more robust integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->