### PR TITLE
Support shorter shots

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.5"
+    "version": "0.7.6"
   },
   "servers": [
     {
@@ -11333,10 +11333,10 @@
           },
           "min_seconds": {
             "type": "number",
-            "minimum": 1,
+            "minimum": 0.6,
             "maximum": 600,
             "nullable": true,
-            "description": "The minimum length of a shot in seconds. Defaults to 1."
+            "description": "The minimum length of a shot in seconds. Defaults to 0.6."
           },
           "max_seconds": {
             "type": "number",
@@ -12702,16 +12702,16 @@
             "description": "Detection algorithm:\n\u2022 **adaptive**: Designed for dynamic footage with camera movement and action (default)\n\u2022 **content**: Optimized for controlled footage with clear visual transitions"
           },
           "max_duration_seconds": {
-            "type": "integer",
+            "type": "number",
             "minimum": 1,
             "maximum": 600,
             "description": "Maximum duration for each segment in seconds (1 second to 10 minutes, default: 5 minutes)"
           },
           "min_duration_seconds": {
-            "type": "integer",
-            "minimum": 1,
+            "type": "number",
+            "minimum": 0.6,
             "maximum": 600,
-            "description": "Minimum duration for each segment in seconds (1 second to 10 minutes, default: 1 second)"
+            "description": "Minimum duration for each segment in seconds (0.6 seconds to 10 minutes, default: 0.6 seconds)"
           },
           "fill_gaps": {
             "type": "boolean",


### PR DESCRIPTION
## Summary

- bumps api version
- makes min seconds for shots 0.6 seconds


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only contract and documentation changes with no runtime code in this diff; clients may start sending shorter min durations once the backend matches.
> 
> **Overview**
> Bumps the OpenAPI **API version** from `0.7.5` to `0.7.6` and relaxes shot-segmentation duration limits so clients can request **shorter minimum shot lengths**.
> 
> For **`SegmentationShotDetectorConfig.min_seconds`** and **`ShotConfig.min_duration_seconds`**, the documented minimum drops from **1s to 0.6s** and the default is updated to **0.6s**. **`ShotConfig`** duration fields are also typed as **`number`** instead of **`integer`**, so fractional second bounds are valid in the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a89fb093740ae332ffff8cfdb85c1b94ad514f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Updates**
  * API version bumped to 0.7.6
  * Shot detection and segmentation configuration now support sub-second durations (minimum 0.6 seconds), enabling more precise control over shot timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->