### PR TITLE
feat: add optional participants to describe request (0.7.7)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.6"
+    "version": "0.7.7"
   },
   "servers": [
     {
@@ -10297,6 +10297,25 @@
               "use_in_default_index": {
                 "type": "boolean",
                 "description": "When true, the video's search documents will be added to the account's default index, making them searchable via the Response API and Deep Search API with `source: 'default'`."
+              },
+              "participants": {
+                "type": "array",
+                "maxItems": 50,
+                "description": "Known participants on the recording. When provided, speaker naming is constrained to these people: transcript speaker labels will only use one of these names (or a generic \"Speaker N\"), never an invented name. Intended for uploaded files, which (unlike data-connector files such as Grain) carry no participant metadata; for connector files this is populated automatically and need not be supplied.",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Participant display name, e.g. \"Alice Smith\"."
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Optional free-form context for the participant, e.g. a role, affiliation, or \"internal\"/\"external\". Used only as naming context."
+                    }
+                  }
+                }
               }
             }
           },
@@ -10362,6 +10381,25 @@
               "enable_audio_description": {
                 "type": "boolean",
                 "description": "Whether the user requested to generate audio description"
+              },
+              "participants": {
+                "type": "array",
+                "maxItems": 50,
+                "description": "Known participants on the recording. When provided, speaker naming is constrained to these people: transcript speaker labels will only use one of these names (or a generic \"Speaker N\"), never an invented name. Intended for uploaded files, which (unlike data-connector files such as Grain) carry no participant metadata; for connector files this is populated automatically and need not be supplied.",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Participant display name, e.g. \"Alice Smith\"."
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Optional free-form context for the participant, e.g. a role, affiliation, or \"internal\"/\"external\". Used only as naming context."
+                    }
+                  }
+                }
               }
             }
           },


### PR DESCRIPTION
Syncs `spec/openapi.json` with the cloudglue monorepo (makeyolo/cloudglue#1226, merged).

## What changed
- **`POST /describe`** gains an optional **`participants`** array (`{ name, scope? }`, `maxItems: 50`) on the request body (`NewDescribe`), echoed back in the response `describe_config`.
- `info.version`: **0.7.6 → 0.7.7**.

When `participants` is supplied, describe constrains speaker naming to that cast: transcript speaker labels only use one of those names (or a generic `Speaker N`), never an invented name. This is for **uploaded files**, which (unlike data-connector files such as Grain) carry no participant metadata — connector files get it populated automatically and don't need to supply it. `scope` is a free-form string (videos aren't always meetings) with `internal`/`external` as documented examples.

## Diff
40 lines: the version bump + the two `participants` blocks (request + response echo). No other changes — the spec was already in sync at 0.7.6.

Downstream: this is the source for SDK generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenAPI sync with no runtime code in this PR; SDK consumers gain an optional request field.
> 
> **Overview**
> Bumps the published API spec to **0.7.7** and documents optional **`participants`** on describe jobs.
> 
> **`POST /describe`** (`NewDescribe`) now accepts an optional `participants` array (up to 50 entries of `{ name, scope? }`). The **`Describe`** response echoes the same field under `describe_config`. When set, describe limits transcript speaker labels to those names or generic `Speaker N` labels—intended for uploads without connector-provided participant metadata.
> 
> This is a spec-only sync for downstream SDK generation; behavior is described in the OpenAPI field docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9211eed38793c3c443f8491764e473ec5ac1049. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional participant specification capability for media descriptions, allowing you to provide known participant names and scopes to improve transcript speaker identification accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->