### PR TITLE
feat: add image file support (API v0.7.8)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.7"
+    "version": "0.7.8"
   },
   "servers": [
     {
@@ -631,11 +631,11 @@
     "/files": {
       "post": {
         "tags": ["Files"],
-        "summary": "Upload a video file that can be used with Cloudglue services",
+        "summary": "Upload a video, audio, or image file that can be used with Cloudglue services",
         "operationId": "uploadFile",
-        "description": "Upload a video file that can be used with Cloudglue services",
+        "description": "Upload a video, audio, or image file that can be used with Cloudglue services",
         "requestBody": {
-          "description": "Upload a video file",
+          "description": "Upload a video, audio, or image file",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -8448,7 +8448,7 @@
             "type": "object",
             "properties": {
               "url": {
-                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs, and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
+                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
                 "type": "string"
               },
               "prompt": {
@@ -8533,8 +8533,8 @@
           },
           "media_type": {
             "type": "string",
-            "enum": ["video", "audio"],
-            "description": "Type of media file (video or audio)"
+            "enum": ["video", "audio", "image"],
+            "description": "Type of media file (video, audio, or image). Images are processed at the file level only (no segmentation)."
           },
           "media_info": {
             "type": "object",
@@ -8654,7 +8654,7 @@
           "file": {
             "type": "string",
             "format": "binary",
-            "description": "The video file to be uploaded"
+            "description": "The video, audio, or image file to be uploaded"
           },
           "metadata": {
             "type": "object",
@@ -10258,7 +10258,7 @@
             "required": ["url"],
             "properties": {
               "url": {
-                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs, and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
+                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
                 "type": "string"
               },
               "enable_summary": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -8448,7 +8448,7 @@
             "type": "object",
             "properties": {
               "url": {
-                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
+                "description": "Input media URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
                 "type": "string"
               },
               "prompt": {
@@ -8547,12 +8547,12 @@
               "width": {
                 "type": "integer",
                 "nullable": true,
-                "description": "Video width in pixels (null for audio files)"
+                "description": "Width in pixels (null for audio files)"
               },
               "height": {
                 "type": "integer",
                 "nullable": true,
-                "description": "Video height in pixels (null for audio files)"
+                "description": "Height in pixels (null for audio files)"
               },
               "sample_rate": {
                 "type": "integer",
@@ -8580,7 +8580,7 @@
                 "description": "Whether the file has audio"
               }
             },
-            "description": "Unified media information for both video and audio files"
+            "description": "Unified media information for video, audio, and image files"
           },
           "video_info": {
             "type": "object",
@@ -10258,7 +10258,7 @@
             "required": ["url"],
             "properties": {
               "url": {
-                "description": "Input video URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
+                "description": "Input media URL. Supports URIs of files uploaded to Cloudglue Files endpoint, public YouTube video URLs, public TikTok video URLs, public Loom share URLs, public HTTP URLs (including direct image URLs such as JPEG/PNG/WebP), and files which have been granted access to Cloudglue via data connectors.\n\nNote that YouTube videos are currently limited to speech level understanding only. Public TikTok video URLs will be scraped and stored automatically \u2014 subject to charges. For files via our Data connectors, see our documentation on data connectors for setup information.",
                 "type": "string"
               },
               "enable_summary": {


### PR DESCRIPTION
## Summary

Extends the Cloudglue API spec to support **image files** alongside video and audio. Bumps `info.version` to `0.7.8`.

Ported from [makeyolo/cloudglue#1240](https://github.com/makeyolo/cloudglue/pull/1240), which adds image input to **on-demand Describe & Extract** (file-level only, 1 credit, no segmentation, not searchable).

## Changes

- **Version:** `info.version` bumped `0.7.7` → `0.7.8`.
- **`POST /files`:** Upload endpoint now accepts video, audio, **or image** files (updated `summary`, `description`, and the binary `file` field description).
- **`media_type` enum:** Added `"image"` to the `["video", "audio"]` enum. Description notes images are processed at the file level only (no segmentation).
- **`File.media_info` docs:** Generalized for images — `width`/`height` drop the video-only lead-in (keeping the "null for audio files" note), and the `media_info` description now reads "video, audio, and image files".
- **URL ingestion (`NewDescribe`, `NewExtract`):** The `url` fields for `POST /describe` and `POST /extract` now document direct image URLs (JPEG/PNG/WebP) over public HTTP, and use a media-neutral **"Input media URL"** lead-in (previously "Input video URL") to match.

## Scope note (deliberately narrower than a naive port)

The upstream PR's `openapi.json` applied the image-URL note to **all four** schemas that share the same URL boilerplate, but PR #1240 only implements image support for **Describe & Extract**. It changes no collections or transcribe code, and images are explicitly non-segmentable (`POST /segments` → 400) and not added to the search index — which is exactly what collection-level processing relies on.

So the image-URL note is **intentionally NOT applied** to:

- **`AddCollectionFile`** — `POST /collections/{id}/videos` and `/collections/{id}/media`. Adding an image to a collection is not supported by #1240.
- **`NewTranscribe`** — `POST /transcribe`. Not in scope (and transcription of a still image is meaningless).

These remain video/audio only, keeping the spec accurate to what the API actually accepts.

## Review

CodeRabbit feedback addressed in `8e22eb4`: media-neutral URL wording (describe/extract only) and the stale `File.media_info` image docs. See the [PR comment](https://github.com/cloudglue/cloudglue-api-spec/pull/102#issuecomment-4840063417) for the per-finding rationale.

## Notes

- Spec-only change; `spec/openapi.json` validated as well-formed JSON.
- No endpoint or schema additions/removals — one additive enum value plus documentation wording.
- Mirrored in the upstream monorepo by [makeyolo/cloudglue#1254](https://github.com/makeyolo/cloudglue/pull/1254) to keep the published specs consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only documentation and enum addition with no runtime code changes; scope is intentionally narrow to avoid overstating API behavior.
> 
> **Overview**
> Bumps the public API spec to **v0.7.8** and documents **image** as a first-class upload and ingest type alongside video and audio.
> 
> **`POST /files`** and file-related schemas now describe video, audio, or image uploads. **`media_type`** gains `"image"`, with wording that images are file-level only (no segmentation). **`media_info`** width/height descriptions are generalized for images.
> 
> **`NewDescribe`** and **`NewExtract`** `url` fields are updated from “input video URL” to **input media URL**, including direct HTTP image URLs (JPEG/PNG/WebP). Collection and transcribe URL schemas are unchanged so the spec stays aligned with Describe/Extract-only image support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e22eb4fc973f4a103e38aa7fce1daf725aaaaf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
