### PR TITLE
feat: add link_preview control for shareable assets (API v0.7.10)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.9"
+    "version": "0.7.10"
   },
   "servers": [
     {
@@ -13816,7 +13816,7 @@
       },
       "ShareableAsset": {
         "type": "object",
-        "required": ["id", "file_id", "url", "created_at"],
+        "required": ["id", "file_id", "url", "link_preview", "created_at"],
         "properties": {
           "id": {
             "type": "string",
@@ -13849,6 +13849,11 @@
             "type": "string",
             "enum": ["public", "private"],
             "description": "The visibility of the shareable asset. 'public' assets are viewable by anyone with the link; 'private' assets are restricted to members of the owning account and stream via a signed, token-gated playback url."
+          },
+          "link_preview": {
+            "type": "string",
+            "enum": ["none", "full"],
+            "description": "Controls rich link-preview (Open Graph) metadata for unfurl bots on private shares. 'none' (default) emits no preview metadata; 'full' emits title, description, and thumbnail. Public shares always emit full metadata regardless of this value."
           },
           "preview_url": {
             "type": "string",
@@ -13923,6 +13928,12 @@
             "enum": ["public", "private"],
             "default": "public",
             "description": "Visibility of the shareable asset. Defaults to 'public'. 'private' restricts the share page to members of the owning account and serves a signed, token-gated stream. Cannot be changed after creation."
+          },
+          "link_preview": {
+            "type": "string",
+            "enum": ["none", "full"],
+            "default": "none",
+            "description": "Rich link-preview metadata for unfurl bots. Only affects private shares: 'none' (default) keeps today's no-preview behavior; 'full' emits title, description, and thumbnail Open Graph tags. Public shares always emit full metadata."
           }
         }
       },
@@ -13940,6 +13951,11 @@
           "metadata": {
             "type": "object",
             "description": "The metadata of the shareable asset"
+          },
+          "link_preview": {
+            "type": "string",
+            "enum": ["none", "full"],
+            "description": "Rich link-preview metadata for unfurl bots. Only affects private shares: 'none' keeps today's no-preview behavior; 'full' emits title, description, and thumbnail Open Graph tags. Public shares always emit full metadata."
           }
         }
       },


### PR DESCRIPTION
## Summary

Bumps the spec to **v0.7.10** and adds a `link_preview` field to the shareable asset schemas, letting callers opt private shares into rich Open Graph metadata for unfurl bots (Slack, iMessage, etc.).

Values are `"none"` (default — no preview metadata, today's behavior) and `"full"` (emits title, description, and thumbnail OG tags). Public shares always emit full metadata regardless of this value.

## Changes

| Schema | Change |
| --- | --- |
| `ShareableAsset` | New `link_preview` property, added to `required` |
| `CreateShareableAssetRequest` | New optional `link_preview`, `default: "none"` |
| `UpdateShareableAssetRequest` | New optional `link_preview` |

## Notes

`link_preview` is **required** on the `ShareableAsset` response schema, so generated clients that strictly validate responses will need the regenerated model. The API must always populate it. Request-side it is optional and backwards compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-only OpenAPI change with optional request fields; main impact is required response field for strict client validators.
> 
> **Overview**
> Bumps the OpenAPI spec to **v0.7.10** and introduces **`link_preview`** on shareable asset create, update, and response schemas.
> 
> Callers can set **`none`** (default) or **`full`** to control whether private share links expose rich Open Graph metadata to unfurl bots; **public shares always emit full metadata** regardless of this field. On **`ShareableAsset`**, `link_preview` is now **required** in the response schema, so clients that strictly validate responses need regenerated models and the API must always return the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabcfa3b2fe6dc8227c0a91eef22e5aa29812713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link preview controls for shareable assets, allowing previews to be set to none or full.
  * Private shares can now control rich link metadata shown by preview services; public shares continue to provide full previews.
  * Share creation and updates now support the new link preview setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->