### PR TITLE
feat: add enable_metadata_mode for entity extraction (API v0.7.12)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.11"
+    "version": "0.7.12"
   },
   "servers": [
     {
@@ -8431,6 +8431,10 @@
               "enable_transcript_mode": {
                 "type": "boolean",
                 "description": "When enabled, extract entities from transcript only (similar to YouTube path). Useful for speech-heavy content."
+              },
+              "enable_metadata_mode": {
+                "type": "boolean",
+                "description": "When enabled, extract entities from the file's metadata document (filename, file details, user metadata, and connector source metadata) instead of the media content. File-level entities only; flat 1 credit per file; works on metadata-only files without ingesting their media. Mutually exclusive with enable_transcript_mode."
               }
             }
           },
@@ -8613,6 +8617,10 @@
               "enable_transcript_mode": {
                 "type": "boolean",
                 "description": "When enabled, extract entities from transcript only (similar to YouTube path). Useful for speech-heavy content."
+              },
+              "enable_metadata_mode": {
+                "type": "boolean",
+                "description": "When enabled, extract entities from the file's metadata document (filename, file details, user metadata, and connector source metadata) instead of the media content. File-level entities only; flat 1 credit per file; works on metadata-only files without ingesting their media. Mutually exclusive with enable_transcript_mode."
               },
               "thumbnails_config": {
                 "$ref": "#/components/schemas/ThumbnailsConfig"
@@ -8924,6 +8932,10 @@
               "enable_transcript_mode": {
                 "type": "boolean",
                 "description": "When enabled, extract entities from transcript only. Useful for speech-heavy content."
+              },
+              "enable_metadata_mode": {
+                "type": "boolean",
+                "description": "When enabled, every file added to this entities collection is extracted from its metadata document (filename, file details, user metadata, and connector source metadata) instead of the media content. File-level entities only; flat 1 credit per file; metadata-only files are never ingested. Mutually exclusive with enable_transcript_mode."
               }
             }
           },
@@ -9134,6 +9146,10 @@
               "enable_transcript_mode": {
                 "type": "boolean",
                 "description": "When enabled, extract entities from transcript only. Useful for speech-heavy content."
+              },
+              "enable_metadata_mode": {
+                "type": "boolean",
+                "description": "When enabled, every file added to this entities collection is extracted from its metadata document (filename, file details, user metadata, and connector source metadata) instead of the media content. File-level entities only; flat 1 credit per file; metadata-only files are never ingested. Mutually exclusive with enable_transcript_mode."
               }
             }
           },


### PR DESCRIPTION
## Summary
- Bump spec version to **0.7.12**
- Add `enable_metadata_mode` boolean to extraction configs:
  - `POST /extract` job config (both request variants)
  - Entities collection `extract_config` (both variants)

## Details
When enabled, entities are extracted from the file's **metadata document** (filename, file details, user metadata, and connector source metadata) instead of the media content:
- File-level entities only
- Flat 1 credit per file
- Works on metadata-only files without ingesting their media
- Mutually exclusive with `enable_transcript_mode`

For entities collections, the mode applies to every file added to the collection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only documentation change with no runtime code in this diff; risk is limited to API contract clarity and downstream client expectations.
> 
> **Overview**
> Bumps the public API spec to **0.7.12** and documents a new **`enable_metadata_mode`** flag on entity extraction configs (extract job config and entities collection `extract_config`, in each schema variant).
> 
> When set, extraction is described as using the file’s **metadata document** (filename, file details, user and connector metadata) instead of media content: **file-level entities only**, **1 credit per file**, support for **metadata-only files without media ingest**, and **mutual exclusivity with `enable_transcript_mode`**. Collection-level configs state that the mode applies to every file added to the collection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca47e0663e5c578fd8e72e8d89d9e1149e9dcea8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->