### PR TITLE
feat: entity and metadata collections in search, deep search, and response KBs (API v0.7.16)

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -7,7 +7,7 @@
       "name": "Apache License 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "0.7.15"
+    "version": "0.7.16"
   },
   "servers": [
     {
@@ -8083,7 +8083,7 @@
             "type": "string",
             "minLength": 1,
             "example": "nimbus-001",
-            "description": "The model to use for generating the response.\n\n- `nimbus-001`: Fast general question answering model. Requires `knowledge_base`. Default temperature: 0.7.\n- `nimbus-002-preview`: Light reasoning model capable of multi-step reasoning, cross-video synthesis, and structured entity data. Requires `knowledge_base`. Supports `entity_collections` in the knowledge base. Default temperature: 1.\n\nMetadata collections (`collection_type: 'metadata'`) in the knowledge base are only supported by `nimbus-002-preview` — its agent retrieves them at file granularity; `nimbus-001` rejects them (400)."
+            "description": "The model to use for generating the response.\n\n- `nimbus-001`: Fast general question answering model. Requires `knowledge_base`. Default temperature: 0.7.\n- `nimbus-002-preview`: Light reasoning model capable of multi-step reasoning, cross-video synthesis, and structured entity data. Requires `knowledge_base`. Supports `entity_collections` in the knowledge base. Default temperature: 1.\n\nMetadata collections (`collection_type: 'metadata'`) and entities collections (`collection_type: 'entities'`) in the knowledge base are only supported by `nimbus-002-preview` — its agent picks the retrieval scope per search call (metadata docs and file-level entity docs at file granularity, segment-level entity docs at segment granularity); `nimbus-001` rejects both (400)."
           },
           "input": {
             "oneOf": [
@@ -8228,7 +8228,7 @@
               "format": "uuid"
             },
             "minItems": 1,
-            "description": "Collection IDs to search for relevant context"
+            "description": "Collection IDs to search for relevant context. Collections must be of type 'rich-transcripts', 'media-descriptions', 'metadata', or 'entities'. Metadata and entities collections require the `nimbus-002-preview` model (its agent picks the retrieval scope per search call); `nimbus-001` rejects them (400). Entities collections are valid at both extraction levels: file-level extraction (enable_video_level_entities or enable_metadata_mode) is retrieved as file-level entity docs, segment-level extraction as per-segment entity docs with real timestamps."
           },
           "filter": {
             "description": "Optional filter to narrow down the search within collections.\n\nSupports filtering by `metadata`, `video_info`, and `file` properties. Each filter is an array of criteria with `path`, `operator`, and `valueText` or `valueTextArray`.\n\nSupported operators: `Equal`, `NotEqual`, `LessThan`, `GreaterThan`, `In`, `ContainsAny`, `ContainsAll`.\n\nExamples:\n- Filter by file ID: `{\"file\": [{\"path\": \"id\", \"operator\": \"Equal\", \"valueText\": \"file-uuid\"}]}`\n- Filter by metadata: `{\"metadata\": [{\"path\": \"speaker\", \"operator\": \"Equal\", \"valueText\": \"Amy\"}]}`\n- Filter by duration: `{\"video_info\": [{\"path\": \"duration_seconds\", \"operator\": \"GreaterThan\", \"valueText\": \"60\"}]}`",
@@ -9793,6 +9793,11 @@
               "not_applicable"
             ],
             "description": "Overall processing status of the file in this collection"
+          },
+          "searchable_status": {
+            "type": "string",
+            "enum": ["pending", "processing", "completed", "failed"],
+            "description": "Indexing status of the file's search documents in this collection. Only present for media-descriptions, rich-transcripts, metadata, and entities collections. For entities collections it tracks entity indexing: file-level collections index one document per file, segment-level collections one per segment."
           },
           "file": {
             "$ref": "#/components/schemas/File",
@@ -12622,7 +12627,7 @@
               "format": "uuid"
             },
             "minItems": 1,
-            "description": "List of collection IDs to search within. \n\nFor text search (scope='file' or 'segment'): All collections must be of collection_type 'media-descriptions' or 'rich-transcripts'. For file-level search, collections must have 'enable_summary: true' in transcribe_config.\n\nFor face search (scope='face'): All collections must be of collection_type 'face-analysis'."
+            "description": "List of collection IDs to search within. \n\nFor text search (scope='file' or 'segment'): All collections must be of collection_type 'media-descriptions', 'rich-transcripts', 'metadata', or 'entities'. For file-level search, 'media-descriptions' and 'rich-transcripts' collections must have 'enable_summary: true' in their config. 'metadata' collections only support scope='file'. 'entities' collections are searchable at the scope matching their extraction level: file-level extraction (enable_video_level_entities or enable_metadata_mode) supports scope='file' only, segment-level extraction (enable_segment_level_entities) supports scope='segment' only.\n\nFor face search (scope='face'): All collections must be of collection_type 'face-analysis'."
           },
           "query": {
             "type": "string",
@@ -14002,7 +14007,7 @@
           ]
         },
         "maxItems": 5,
-        "description": "Specifies the type(s) of search to execute. When multiple modalities are specified, a hybrid search is executed that combines results from each modality.\n\nAvailable modalities:\n- `general_content`: baseline for matching the content of the search item (file/segment) based on visual or spoken content similarity to provided short natural language query string\n- `speech_lexical`: performs keyword based search (e.g. query of `president` matching `president` or `presidential` strings) and exact match (e.g. specifically find mentions of `\"Barack Obama\"` or `\"Donald Trump\"`) against speech content present in search item\n- `ocr_lexical`: performs keyword based search and exact match against screen text content present in search item\n- `tag_semantic`: performs basic word semantic similarity search against tag values associated with search items (e.g. `query=animal` expected to match tags with value containing `dog` or `cat`)\n- `tag_lexical`: performs keyword based search and exact match against tag values associated with search items\n- `doc_lexical`: performs keyword based search and exact match against file-level documents (metadata-collection docs and generated summaries). Only applicable when search `scope=file`.\n\nOnly applicable when search `scope=file` or `scope=segment`.\n"
+        "description": "Specifies the type(s) of search to execute. When multiple modalities are specified, a hybrid search is executed that combines results from each modality.\n\nAvailable modalities:\n- `general_content`: baseline for matching the content of the search item (file/segment) based on visual or spoken content similarity to provided short natural language query string\n- `speech_lexical`: performs keyword based search (e.g. query of `president` matching `president` or `presidential` strings) and exact match (e.g. specifically find mentions of `\"Barack Obama\"` or `\"Donald Trump\"`) against speech content present in search item\n- `ocr_lexical`: performs keyword based search and exact match against screen text content present in search item\n- `tag_semantic`: performs basic word semantic similarity search against tag values associated with search items (e.g. `query=animal` expected to match tags with value containing `dog` or `cat`)\n- `tag_lexical`: performs keyword based search and exact match against tag values associated with search items\n- `doc_lexical`: performs keyword based search and exact match against file-level documents (generated summaries, metadata-collection docs, and entity-collection docs). Only applicable when search `scope=file`.\n\nOnly applicable when search `scope=file` or `scope=segment`.\n"
       },
       "ThumbnailType": {
         "type": "string",
@@ -14659,8 +14664,7 @@
           "scope": {
             "type": "string",
             "enum": ["segment", "file"],
-            "default": "segment",
-            "description": "The scope of results to return. 'segment' returns individual segments, 'file' returns file-level results. When the knowledge base contains any metadata collections, scope must be 'file' (metadata collections only index file-level documents)."
+            "description": "The scope of results to return. 'segment' returns individual segments, 'file' returns file-level results — explicit values behave exactly as before, and every collection in the knowledge base must be searchable at the requested scope (metadata and file-level entities collections require 'file'; segment-level entities collections require 'segment'). Omit for auto: the search planner picks a scope per search plan, each collection is searched at the scopes its documents support, and results from both scopes are fused — so a knowledge base can mix collection types (e.g. rich-transcripts + metadata + entities) without a scope."
           },
           "limit": {
             "type": "integer",
@@ -14711,7 +14715,7 @@
               "format": "uuid"
             },
             "minItems": 1,
-            "description": "Collection IDs to search. Collections must be of type rich-transcripts or media-descriptions."
+            "description": "Collection IDs to search. Collections must be of type rich-transcripts, media-descriptions, metadata, or entities. With an explicit scope, every collection must be searchable at it: metadata collections only have file-level docs and require scope='file'; entities collections follow their extraction level — file-level extraction (enable_video_level_entities or enable_metadata_mode) requires scope='file', segment-level extraction (enable_segment_level_entities) requires scope='segment'. When scope is omitted (auto), collection types can be mixed freely: each collection is searched at the scopes its documents support."
           },
           "filter": {
             "description": "Optional filter to narrow down the search within collections.",
@@ -14910,7 +14914,8 @@
           "scope": {
             "type": "string",
             "enum": ["segment", "file"],
-            "description": "The scope of the search results"
+            "nullable": true,
+            "description": "The scope the caller requested. Null when the request omitted scope (auto: the planner chose scopes per search plan, so results may mix segment and file types)."
           },
           "text": {
             "type": "string",
@@ -14993,7 +14998,8 @@
           "scope": {
             "type": "string",
             "enum": ["segment", "file"],
-            "description": "Search scope"
+            "nullable": true,
+            "description": "The scope the caller requested; null when the request omitted scope (auto)"
           },
           "total": {
             "type": "integer",


### PR DESCRIPTION
## Summary

Bumps the spec to **v0.7.16**. Entities (and metadata) collections become first-class search sources across the platform: direct search, deep search knowledge bases, and Response API knowledge bases — plus an auto scope mode for deep search and a per-file indexing status on collection files.

### Search API
- `SearchRequest.collections` now accepts **entities** collections alongside media-descriptions/rich-transcripts/metadata
- `doc_lexical` extends to entity-collection documents (generated summaries, metadata-collection docs, entity-collection docs)

### Deep search
- KB `collections` may be rich-transcripts, media-descriptions, **metadata, or entities**
- **`scope` is now optional — omit for auto**: the search planner picks a scope per search plan and each collection is searched at the scope it supports, so results may mix segment and file types. `DeepSearch.scope` / `DeepSearchListItem.scope` are now **nullable** (null = auto). Explicit values behave exactly as before, and require every collection to be searchable at that scope (metadata + file-level entities → `file`; segment-level entities → `segment`)

### Response API
- Knowledge bases accept metadata and entities collections directly — `nimbus-002-preview` only (its agent picks the retrieval scope per search call); `nimbus-001` rejects them (400)

### Collections
- `CollectionFile` gains `searchable_status` (`pending`/`processing`/`completed`/`failed`) — indexing status of the file's search documents, present for media-descriptions, rich-transcripts, metadata, and entities collections

## Notes

- Response-side `scope` turning nullable is the only shape change; strict clients need regenerated models. Request-side everything is backwards compatible (explicit scopes behave exactly as before).

## Test plan

- [x] `openapi.json` parses as valid JSON (66 paths, 169 schemas — no new paths/schemas, doc + field-level changes only)
- [x] `searchable_status` enum consistent with other status enums; nullable `scope` mirrored in both DeepSearch response schemas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Spec-only but changes client contracts (nullable deep-search scope, new searchable_status); backend must enforce new collection/scope rules consistently.
> 
> **Overview**
> Bumps the OpenAPI spec to **v0.7.16** and documents **metadata** and **entities** collections as searchable sources across Search, Deep Search knowledge bases, and Response API knowledge bases (`nimbus-002-preview` only for KB; `nimbus-001` returns 400).
> 
> **Search** `collections` and **`doc_lexical`** now cover entity-collection documents, with scope rules tied to extraction level (file vs segment). **Deep Search** makes **`scope` optional**: omit for auto planning/fusion across mixed collection types; explicit `file`/`segment` behavior is unchanged but all collections must support that scope. **`DeepSearch.scope`** and list-item **`scope`** are **nullable** when the request omitted scope.
> 
> **`CollectionFile`** adds **`searchable_status`** for indexing of search documents on media-descriptions, rich-transcripts, metadata, and entities collections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d54d7c7de6c94bb6be8e3995e0c6fc9373b42c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->